### PR TITLE
Upgrade jsdom canvas

### DIFF
--- a/lib/pdfjs-utils/domfacade.js
+++ b/lib/pdfjs-utils/domfacade.js
@@ -10,7 +10,7 @@ const utils = require("jsdom/lib/jsdom/living/generated/utils");
 const impl = utils.implSymbol;
 const HTMLElement = require("jsdom/lib/jsdom/living/generated/HTMLElement");
 const HTMLCanvasElement = require("jsdom/lib/jsdom/living/generated/HTMLCanvasElement");
-const { Canvas, Context2d } = require("jsdom/lib/jsdom/utils").Canvas;
+const { Canvas, Context2d, Image, ImageData } = require("jsdom/lib/jsdom/utils").Canvas;
 
 Object.defineProperty(HTMLCanvasElement.expose.Window.HTMLCanvasElement.prototype, "_canvas", {
 	get() {
@@ -196,8 +196,8 @@ Object.defineProperty(Canvas.prototype, "getContext", {
 });
 
 exports.HTMLElement = HTMLElement.expose.Window.HTMLElement;
-exports.Image = Canvas.Image;
-exports.ImageData = Canvas.ImageData;
+exports.Image = Image;
+exports.ImageData = ImageData;
 exports.jsDomFactory = function () {
 	return new JSDOM(`<html>
 <head>

--- a/lib/pdfjs-utils/domfacade.js
+++ b/lib/pdfjs-utils/domfacade.js
@@ -10,7 +10,7 @@ const utils = require("jsdom/lib/jsdom/living/generated/utils");
 const impl = utils.implSymbol;
 const HTMLElement = require("jsdom/lib/jsdom/living/generated/HTMLElement");
 const HTMLCanvasElement = require("jsdom/lib/jsdom/living/generated/HTMLCanvasElement");
-const Canvas  = require("jsdom/lib/jsdom/utils").Canvas;
+const { Canvas, Context2d } = require("jsdom/lib/jsdom/utils").Canvas;
 
 Object.defineProperty(HTMLCanvasElement.expose.Window.HTMLCanvasElement.prototype, "_canvas", {
 	get() {
@@ -117,7 +117,7 @@ exports.canvasFontRegistry = canvasFontRegistry;
 Object.defineProperty(Canvas.prototype, "getContext", {
 	value: function(contextId) {
 		if ('2d' == contextId) {
-			let ctx = this._context2d || (this._context2d = new Canvas.Context2d(this));
+			let ctx = this._context2d || (this._context2d = new Context2d(this));
 			this.context = ctx;
 			ctx.canvas = this;
 
@@ -234,7 +234,7 @@ if (typeof atob === 'undefined') {
 exports.setGlobalDom = function(jsDomInstance) {
 	let jsDom = jsDomInstance || jsDomFactory();
 
-	Object.defineProperty(jsDom.window._core.CSSStyleDeclaration.prototype, 'transform', {
+	Object.defineProperty(jsDom.window.CSSStyleDeclaration.prototype, 'transform', {
 		get : function () {
 			return this.getPropertyValue('transform');
 		},

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^2.9.34",
-    "canvas": "^1.6.7",
-    "jsdom": "11.3.*",
+    "canvas": "^2.0.1",
+    "jsdom": "13.0.*",
     "opentype.js": "^0.7.3",
     "pdfjs-dist": "2.0.402",
     "stack-trace": "^0.0.10"


### PR DESCRIPTION
Upgrades jsdom and canvas to the latest packages. This should make pdf-extractor easier to install since canvas >= 2 comes with pre-built binaries automatically.

Made the proper adjustments to domfacade to deal with the changes made to jsdom and canvas.